### PR TITLE
Catch Keyerror when pointing to non existing group

### DIFF
--- a/h5io_browser/pointer.py
+++ b/h5io_browser/pointer.py
@@ -315,7 +315,7 @@ class Pointer(MutableMapping):
                 h5_path=self._h5_path,
                 recursive=True,
             )
-        except FileNotFoundError:
+        except (FileNotFoundError, KeyError):
             return {}
         else:
             if self._h5_path == "/":


### PR DESCRIPTION
If the HDF5 file exists, but Pointer is indexed to a not (yet) existing group, to_dict()/repr throw errors because the code only checks for FileNotFoundError.