### PR TITLE
list_hdf(): Add return_types parameter

### DIFF
--- a/h5io_browser/base.py
+++ b/h5io_browser/base.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, List, Optional, Tuple, Type, TypeVar, Union
 import h5io
 import h5py
 import numpy as np
-from torch.return_types import return_types
 
 T = TypeVar("T")
 

--- a/h5io_browser/base.py
+++ b/h5io_browser/base.py
@@ -43,8 +43,13 @@ def delete_item(file_name: str, h5_path: str) -> None:
 
 
 def list_hdf(
-    file_name: str, h5_path: str, recursive: Union[bool, int] = False, return_types: bool = False
-) -> Union[Tuple[List[str], List[str]], Tuple[List[str], List[str], List[str], List[str]]]:
+    file_name: str,
+    h5_path: str,
+    recursive: Union[bool, int] = False,
+    return_types: bool = False,
+) -> Union[
+    Tuple[List[str], List[str]], Tuple[List[str], List[str], List[str], List[str]]
+]:
     """
     List HDF5 nodes and HDF5 groups of a given HDF5 file at a given h5_path
 
@@ -63,7 +68,9 @@ def list_hdf(
     if os.path.exists(file_name):
         with h5py.File(file_name, "r") as hdf:
             try:
-                return _get_hdf_content(hdf=hdf[h5_path], recursive=recursive, return_types=return_types)
+                return _get_hdf_content(
+                    hdf=hdf[h5_path], recursive=recursive, return_types=return_types
+                )
             except KeyError:
                 if return_types:
                     return [], [], [], []
@@ -414,7 +421,11 @@ def _write_hdf5_with_json_support(
         ) from None
 
 
-def _list_h5path(hdf: Union[h5py.File, h5py.Group], return_types: bool = False) -> Union[Tuple[List[str], List[str]], Tuple[List[str], List[str], List[str], List[str]]]:
+def _list_h5path(
+    hdf: Union[h5py.File, h5py.Group], return_types: bool = False
+) -> Union[
+    Tuple[List[str], List[str]], Tuple[List[str], List[str], List[str], List[str]]
+]:
     """
     List groups and nodes in a given HDF5 path
 
@@ -472,8 +483,12 @@ def _get_hdf_content(
     recursive: Union[bool, int] = False,
     only_groups: bool = False,
     only_nodes: bool = False,
-    return_types: bool = False
-) -> Union[List[str], Tuple[List[str], List[str]], Tuple[List[str], List[str], List[str], List[str]]]:
+    return_types: bool = False,
+) -> Union[
+    List[str],
+    Tuple[List[str], List[str]],
+    Tuple[List[str], List[str], List[str], List[str]],
+]:
     """
     Get all sub-groups of a given HDF5 path
 
@@ -506,9 +521,16 @@ def _get_hdf_content(
             recursive -= 1
         group_lst, group_types_lst = [], []
         if return_types:
-            nodes_lst, nodes_types_lst, groups_to_iterate_lst, group_types_to_iterate_lst = _list_h5path(hdf=hdf, return_types=return_types)
+            (
+                nodes_lst,
+                nodes_types_lst,
+                groups_to_iterate_lst,
+                group_types_to_iterate_lst,
+            ) = _list_h5path(hdf=hdf, return_types=return_types)
         else:
-            nodes_lst, groups_to_iterate_lst = _list_h5path(hdf=hdf, return_types=return_types)
+            nodes_lst, groups_to_iterate_lst = _list_h5path(
+                hdf=hdf, return_types=return_types
+            )
             nodes_types_lst = []
             group_types_to_iterate_lst = groups_to_iterate_lst
         for group, group_type in zip(groups_to_iterate_lst, group_types_to_iterate_lst):
@@ -545,19 +567,25 @@ def _get_hdf_content(
                 return nodes_lst, group_lst
     elif only_groups:
         if return_types:
-            _, _, group_lst, group_types_lst = _list_h5path(hdf=hdf, return_types=return_types)
+            _, _, group_lst, group_types_lst = _list_h5path(
+                hdf=hdf, return_types=return_types
+            )
             return group_lst, group_types_lst
         else:
             return _list_h5path(hdf=hdf, return_types=return_types)[1]
     elif only_nodes:
         if return_types:
-            nodes_lst, nodes_types_lst, _, _ = _list_h5path(hdf=hdf, return_types=return_types)
+            nodes_lst, nodes_types_lst, _, _ = _list_h5path(
+                hdf=hdf, return_types=return_types
+            )
             return nodes_lst, nodes_types_lst
         else:
             return _list_h5path(hdf=hdf, return_types=return_types)[0]
     else:
         if return_types:
-            nodes_lst, nodes_types_lst, group_lst, group_types_lst = _list_h5path(hdf=hdf, return_types=return_types)
+            nodes_lst, nodes_types_lst, group_lst, group_types_lst = _list_h5path(
+                hdf=hdf, return_types=return_types
+            )
             return nodes_lst, nodes_types_lst, group_lst, group_types_lst
         else:
             nodes_lst, group_lst = _list_h5path(hdf=hdf, return_types=return_types)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -301,32 +301,44 @@ class TestBaseHierachical(TestCase):
             list_hdf(file_name=self.file_name, h5_path="/", recursive=1.0)
 
     def test_list_group_types(self):
-        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path=self.h5_path, return_types=True)
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name, h5_path=self.h5_path, return_types=True
+        )
         self.assertEqual(groups, ["/data_hierarchical/c"])
         self.assertEqual(group_types, [None])
         self.assertEqual(nodes, ["/data_hierarchical/a", "/data_hierarchical/b"])
         self.assertEqual(node_types, ["json", "int"])
-        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/wrong_path", return_types=True)
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name, h5_path="/wrong_path", return_types=True
+        )
         self.assertEqual(nodes, [])
         self.assertEqual(groups, [])
         self.assertEqual(node_types, [])
         self.assertEqual(group_types, [])
-        nodes, node_types, groups, group_types = list_hdf(file_name="empty.h5", h5_path=self.h5_path, return_types=True)
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name="empty.h5", h5_path=self.h5_path, return_types=True
+        )
         self.assertEqual(nodes, [])
         self.assertEqual(groups, [])
         self.assertEqual(node_types, [])
         self.assertEqual(group_types, [])
-        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/", return_types=True)
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name, h5_path="/", return_types=True
+        )
         self.assertEqual(groups, ["/data_hierarchical"])
         self.assertEqual(nodes, [])
         self.assertEqual(node_types, [])
         self.assertEqual(group_types, [None])
-        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/", recursive=1, return_types=True)
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name, h5_path="/", recursive=1, return_types=True
+        )
         self.assertEqual(groups, ["/data_hierarchical", "/data_hierarchical/c"])
         self.assertEqual(group_types, [None, None])
         self.assertEqual(nodes, ["/data_hierarchical/a", "/data_hierarchical/b"])
         self.assertEqual(node_types, ["json", "int"])
-        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/", recursive=2, return_types=True)
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name, h5_path="/", recursive=2, return_types=True
+        )
         self.assertEqual(groups, ["/data_hierarchical", "/data_hierarchical/c"])
         self.assertEqual(
             nodes,
@@ -337,10 +349,13 @@ class TestBaseHierachical(TestCase):
                 "/data_hierarchical/c/e",
             ],
         )
-        self.assertEqual(node_types, ['json', 'int', 'int', 'int'])
+        self.assertEqual(node_types, ["json", "int", "int", "int"])
         self.assertEqual(group_types, [None, None])
         nodes, node_types, groups, group_types = list_hdf(
-            file_name=self.file_name, h5_path=self.h5_path, recursive=True, return_types=True
+            file_name=self.file_name,
+            h5_path=self.h5_path,
+            recursive=True,
+            return_types=True,
         )
         self.assertEqual(groups, ["/data_hierarchical/c"])
         self.assertEqual(
@@ -352,7 +367,7 @@ class TestBaseHierachical(TestCase):
                 "/data_hierarchical/c/e",
             ],
         )
-        self.assertEqual(node_types, ['json', 'int', 'int', 'int'])
+        self.assertEqual(node_types, ["json", "int", "int", "int"])
         self.assertEqual(group_types, [None])
         nodes, node_types, groups, group_types = list_hdf(
             file_name=self.file_name,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,6 @@
 import os
+from runpy import run_path
+
 import numpy as np
 import h5py
 from unittest import TestCase
@@ -295,6 +297,73 @@ class TestBaseHierachical(TestCase):
         )
         self.assertEqual(groups, [])
         self.assertEqual(nodes, [])
+        with self.assertRaises(TypeError):
+            list_hdf(file_name=self.file_name, h5_path="/", recursive=1.0)
+
+    def test_list_group_types(self):
+        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path=self.h5_path, return_types=True)
+        self.assertEqual(groups, ["/data_hierarchical/c"])
+        self.assertEqual(group_types, [None])
+        self.assertEqual(nodes, ["/data_hierarchical/a", "/data_hierarchical/b"])
+        self.assertEqual(node_types, ["json", "int"])
+        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/wrong_path", return_types=True)
+        self.assertEqual(nodes, [])
+        self.assertEqual(groups, [])
+        self.assertEqual(node_types, [])
+        self.assertEqual(group_types, [])
+        nodes, node_types, groups, group_types = list_hdf(file_name="empty.h5", h5_path=self.h5_path, return_types=True)
+        self.assertEqual(nodes, [])
+        self.assertEqual(groups, [])
+        self.assertEqual(node_types, [])
+        self.assertEqual(group_types, [])
+        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/", return_types=True)
+        self.assertEqual(groups, ["/data_hierarchical"])
+        self.assertEqual(nodes, [])
+        self.assertEqual(node_types, [])
+        self.assertEqual(group_types, [None])
+        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/", recursive=1, return_types=True)
+        self.assertEqual(groups, ["/data_hierarchical", "/data_hierarchical/c"])
+        self.assertEqual(group_types, [None, None])
+        self.assertEqual(nodes, ["/data_hierarchical/a", "/data_hierarchical/b"])
+        self.assertEqual(node_types, ["json", "int"])
+        nodes, node_types, groups, group_types = list_hdf(file_name=self.file_name, h5_path="/", recursive=2, return_types=True)
+        self.assertEqual(groups, ["/data_hierarchical", "/data_hierarchical/c"])
+        self.assertEqual(
+            nodes,
+            [
+                "/data_hierarchical/a",
+                "/data_hierarchical/b",
+                "/data_hierarchical/c/d",
+                "/data_hierarchical/c/e",
+            ],
+        )
+        self.assertEqual(node_types, ['json', 'int', 'int', 'int'])
+        self.assertEqual(group_types, [None, None])
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name, h5_path=self.h5_path, recursive=True, return_types=True
+        )
+        self.assertEqual(groups, ["/data_hierarchical/c"])
+        self.assertEqual(
+            nodes,
+            [
+                "/data_hierarchical/a",
+                "/data_hierarchical/b",
+                "/data_hierarchical/c/d",
+                "/data_hierarchical/c/e",
+            ],
+        )
+        self.assertEqual(node_types, ['json', 'int', 'int', 'int'])
+        self.assertEqual(group_types, [None])
+        nodes, node_types, groups, group_types = list_hdf(
+            file_name=self.file_name,
+            h5_path=posixpath.join(self.h5_path, "a"),
+            recursive=True,
+            return_types=True,
+        )
+        self.assertEqual(groups, [])
+        self.assertEqual(nodes, [])
+        self.assertEqual(node_types, [])
+        self.assertEqual(group_types, [])
         with self.assertRaises(TypeError):
             list_hdf(file_name=self.file_name, h5_path="/", recursive=1.0)
 


### PR DESCRIPTION
When the return_types parameter is set to True list_hdf() not only returns the names of the nodes and groups stored in an HDF5 file but also the types of these nodes and groups. This should simplify the implementation of lazy loading approaches.