### PR TITLE
Introduce HDF file cache

### DIFF
--- a/h5io_browser/base.py
+++ b/h5io_browser/base.py
@@ -230,8 +230,6 @@ def _merge_nested_dict(main_dict: dict, add_dict: dict) -> dict:
             main_dict[k] = v
     return main_dict
 
-from collections import defaultdict
-_FILE_HANDLE_CACHE_COUNTER = defaultdict(int)
 _FILE_HANDLE_CACHE = {}
 
 def _fetch_handle(filename, mode):
@@ -247,7 +245,6 @@ def _fetch_handle(filename, mode):
     for mode in acceptable_modes:
         handle = _FILE_HANDLE_CACHE.get((filename, mode), None)
         if handle is not None:
-            _FILE_HANDLE_CACHE_COUNTER[filename, mode] += 1
             return handle
 
 class HdfCacheWarning(UserWarning):
@@ -286,7 +283,6 @@ def CachedHDF(filename: str, mode: str = "r"):
         yield handle
     else:
         with _open_hdf(filename, mode, swmr=True) as handle:
-            _FILE_HANDLE_CACHE_COUNTER[filename, handle.mode] = 0
             _FILE_HANDLE_CACHE[filename, handle.mode] = handle
             try:
                 yield handle
@@ -298,8 +294,6 @@ def CachedHDF(filename: str, mode: str = "r"):
                                   "You should not manually close file handles obtained from this function.",
                                   category=HdfCacheWarning, stacklevel=2)
                 _FILE_HANDLE_CACHE.pop((filename, handle.mode), None)
-                count = _FILE_HANDLE_CACHE_COUNTER.pop((filename, handle.mode), 0)
-                print(f"Saved {count} open on {filename}")
 
 def _open_hdf(filename: str, mode: str = "r", swmr: bool = False) -> h5py.File:
     """

--- a/h5io_browser/base.py
+++ b/h5io_browser/base.py
@@ -248,19 +248,12 @@ def CachedHDF(filename: str, mode: str = "r", swmr: bool = False):
     else:
         with _open_hdf(filename, mode, swmr) as handle:
             _FILE_HANDLE_CACHE[filename] = handle
-            # Monkey patch close so that downstream code can use the handle as a context manager without closing the
-            # file we want to cache
-            handle.close = lambda: None
             try:
                 yield handle
             finally:
                 if not handle: # HDF file are true-ish when open, false-ish when not
                     print("ALARM, ALARM!")
-
                 del _FILE_HANDLE_CACHE[filename]
-                # deleting the *instance* attribute we added above, afterwards close will resolve to the class attr that is
-                # the method
-                del handle.close
                 count = _FILE_HANDLE_CACHE_COUNTER.pop(filename, 0)
                 print(f"Saved {count} open on {filename}")
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,6 +12,7 @@ from h5io_browser import (
     write_dict_to_hdf,
 )
 from h5io_browser.base import (
+    WithOpenHDF,
     _get_hdf_content,
     _is_ragged_in_1st_dim_only,
     _read_dict_from_open_hdf,
@@ -140,72 +141,73 @@ class TestBaseHierachical(TestCase):
         )
 
     def test_read_nested_dict_hierarchical(self):
-        self.assertEqual(
-            {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path=self.h5_path,
-                recursive=True,
-            ),
-        )
-        self.assertEqual(
-            {"data_hierarchical": {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}}},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path="/",
-                recursive=True,
-            ),
-        )
-        self.assertEqual(
-            {"d": 4, "e": 5},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path=posixpath.join(self.h5_path, "c"),
-                recursive=True,
-            ),
-        )
-        self.assertEqual(
-            {"a": [1, 2], "b": 3},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path=self.h5_path,
-                recursive=False,
-            ),
-        )
-        self.assertEqual(
-            {"a": [1, 2]},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path=posixpath.join(self.h5_path, "a"),
-                recursive=False,
-            ),
-        )
-        self.assertEqual(
-            {"b": 3},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path=posixpath.join(self.h5_path, "b"),
-                recursive=False,
-            ),
-        )
-        self.assertEqual(
-            {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path=self.h5_path,
-                group_paths=[posixpath.join(self.h5_path, "c")],
-                recursive=False,
-            ),
-        )
-        self.assertEqual(
-            {"data_hierarchical": {"c": {"d": 4, "e": 5}}},
-            read_dict_from_hdf(
-                file_name=self.file_name,
-                h5_path="/",
-                group_paths=[posixpath.join(self.h5_path, "c")],
-                recursive=False,
-            ),
-        )
+        with WithOpenHDF(self.file_name):
+            self.assertEqual(
+                {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path=self.h5_path,
+                    recursive=True,
+                ),
+            )
+            self.assertEqual(
+                {"data_hierarchical": {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}}},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path="/",
+                    recursive=True,
+                ),
+            )
+            self.assertEqual(
+                {"d": 4, "e": 5},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path=posixpath.join(self.h5_path, "c"),
+                    recursive=True,
+                ),
+            )
+            self.assertEqual(
+                {"a": [1, 2], "b": 3},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path=self.h5_path,
+                    recursive=False,
+                ),
+            )
+            self.assertEqual(
+                {"a": [1, 2]},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path=posixpath.join(self.h5_path, "a"),
+                    recursive=False,
+                ),
+            )
+            self.assertEqual(
+                {"b": 3},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path=posixpath.join(self.h5_path, "b"),
+                    recursive=False,
+                ),
+            )
+            self.assertEqual(
+                {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path=self.h5_path,
+                    group_paths=[posixpath.join(self.h5_path, "c")],
+                    recursive=False,
+                ),
+            )
+            self.assertEqual(
+                {"data_hierarchical": {"c": {"d": 4, "e": 5}}},
+                read_dict_from_hdf(
+                    file_name=self.file_name,
+                    h5_path="/",
+                    group_paths=[posixpath.join(self.h5_path, "c")],
+                    recursive=False,
+                ),
+            )
 
     def test_read_hdf(self):
         self.assertEqual(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,7 +12,7 @@ from h5io_browser import (
     write_dict_to_hdf,
 )
 from h5io_browser.base import (
-    WithOpenHDF,
+    CachedHDF,
     _get_hdf_content,
     _is_ragged_in_1st_dim_only,
     _read_dict_from_open_hdf,
@@ -141,7 +141,7 @@ class TestBaseHierachical(TestCase):
         )
 
     def test_read_nested_dict_hierarchical(self):
-        with WithOpenHDF(self.file_name):
+        with CachedHDF(self.file_name):
             self.assertEqual(
                 {"a": [1, 2], "b": 3, "c": {"d": 4, "e": 5}},
                 read_dict_from_hdf(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -570,16 +570,15 @@ class CachedTestMixin:
         # Test with an append mode file cache, if test request read mode files
         # it will still receive the cached handle
         cache = CachedHDF(self.file_name, "a")
-        if sys.version_info.major == 3 and sys.version_info.minor >= 11:
-            self.enterContext(cache)
-        else:
-            # Poor man's enterContext, because that only landed in 3.11
-            self._context = cache
-            cache.__enter__()
+        # Poor man's enterContext, it seems if enterContext is used the clean
+        # up action is only performed after the tearDown and so tearDown and
+        # context manager contest the underlying hdf5 files and that causes
+        # errors on windows
+        self._context = cache
+        cache.__enter__()
 
     def tearDown(self):
-        if sys.version_info.major == 3 and sys.version_info.minor < 11:
-            self._context.__exit__(None, None, None)
+        self._context.__exit__(None, None, None)
         super().tearDown()
 
 class TestBaseHierachicalCached(CachedTestMixin, TestBaseHierachical):


### PR DESCRIPTION
With a new context manager `CachedHDF`, users can request a file handle from `h5io_browser` that stays open for the duration of manager.  The context manager can be nested.  To implement this I added a new function `open_hdf5` and replaced all calls to `_open_hdf5`.  By default this function does nothing but check whether a requested file is already in the cache.  If instructed so `cache=True` it uses the context manager to create a new cache entry and returns that.

I augmented to test suite to run the tests where it makes sense under the caching context as well.